### PR TITLE
Galleries and source lists

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,18 @@ Save your changes at the bottom of the page (you may need to click out of the in
 
 As with using Stash images, you can set a comma-separated list of URLs here and one will be chosen at random to be displayed on hover. However, any URL that has a comma in it will break.
 
+## Hover galleries
+
+To add a hover gallery to a performer, navigate to the performer's page and click "Edit". Scroll down to "Custom Fields" near the bottom of the page and click it to start adding fields.
+
+Add a field with the name `hovercard_gallery`. In the value field, add a comma-separated list of Stash IDs of the galleries you want to use choose an image from. The gallery ID can be found by navigating to the gallery in Stash and taking the number after `galleries/`; for example, for an image at http://localhost:9999/galleries/69 the Stash ID would be 69.
+
+![image](https://github.com/user-attachments/assets/1c888987-fd19-4bfa-8267-42f81b2376ab)
+
+Save your changes at the bottom of the page (you may need to click out of the input field first). Your performer should now display a random image from one of the chosen galleries when you hover over it. Images change on page refresh, not on each hover.
+
+External galleries are not currently supported.
+
 ## Hover videos
 
 To add a hover video to a performer, navigate to the performer's page and click "Edit". Scroll down to "Custom Fields" near the bottom of the page and click it to start adding fields.

--- a/Readme.md
+++ b/Readme.md
@@ -37,11 +37,11 @@ Add a field with the name `hovercard_image`. The contents of the value field dep
 
 ### Stash images
 
-To add an image that is in your Stash library, add the Stash ID of the image you want to use in the `hovercard_image` value field. The image ID can be found by navigating to the image in Stash and taking the number after `images/`; for example, for an image at http://localhost:9999/images/3 the Stash ID would be 3.
+To add an image that is in your Stash library, add a comma-separated list of Stash IDs of the images you want to use in the `hovercard_image` value field. The image ID can be found by navigating to the image in Stash and taking the number after `images/`; for example, for an image at http://localhost:9999/images/3 the Stash ID would be 3.
 
-![image](https://github.com/user-attachments/assets/9f07f7fb-bf42-42c7-a9a3-4110deb5370e)
+![image](https://github.com/user-attachments/assets/dae448f9-206d-450b-ad3d-35a71712228b)
 
-Save your changes at the bottom of the page (you may need to click out of the input field first). Your performer should now display your chosen image when you hover over it.
+Save your changes at the bottom of the page (you may need to click out of the input field first). Your performer should now display a random one of the chosen images when you hover over it. Images change on page refresh, not on each hover.
 
 The Stash ID of the image will always be a number. Any value that is not a number is treated as an external image.
 
@@ -53,6 +53,8 @@ To add an image from outside of your library, such as from a different website, 
 
 Save your changes at the bottom of the page (you may need to click out of the input field first). Your performer should now display your chosen image when you hover over it.
 
+As with using Stash images, you can set a comma-separated list of URLs here and one will be chosen at random to be displayed on hover. However, any URL that has a comma in it will break.
+
 ## Hover videos
 
 To add a hover video to a performer, navigate to the performer's page and click "Edit". Scroll down to "Custom Fields" near the bottom of the page and click it to start adding fields.
@@ -61,11 +63,11 @@ Add a field with the name `hovercard_video`. The contents of the value field dep
 
 ### Stash scene previews
 
-To add the preview video of a scene that is in your Stash library, add the Stash ID of the scene you want to use in the `hovercard_video` value field. The scene ID can be found by navigating to the scene in Stash and taking the number after `scenes/`; for example, for a scene at http://localhost:9999/scenes/5 the Stash ID would be 5.
+To add the preview video of a scene that is in your Stash library, add a comma-separated list of Stash IDs of the scenes you want to use in the `hovercard_video` value field. The scene ID can be found by navigating to the scene in Stash and taking the number after `scenes/`; for example, for a scene at http://localhost:9999/scenes/5 the Stash ID would be 5.
 
-![image](https://github.com/user-attachments/assets/8a705596-cc98-4c47-a689-f9c3ce20fcc4)
+![image](https://github.com/user-attachments/assets/e1c65ae6-751e-4a9f-b953-e3ba8c6cb3a1)
 
-Save your changes at the bottom of the page (you may need to click out of the input field first). Your performer should now display your chosen scene preview when you hover over it.
+Save your changes at the bottom of the page (you may need to click out of the input field first). Your performer should now display a random one of the chosen scene previews when you hover over it.
 
 The Stash ID of the scene will always be a number. Any value that is not a number is treated as a local file path.
 
@@ -87,6 +89,8 @@ Once you have the URL, remove the domain name to get the absolute path. This can
 
 ![image](https://github.com/user-attachments/assets/12acdb84-456f-49e3-9495-a8afdb0c7a7a)
 
+As with using Stash scenes, you can set a comma-separated list of URLs here and one will be chosen at random to be displayed on hover.
+
 ### Local video files - bare metal install (untested)
 
 To add a local video file, simply add the full path of the video file as the field value.
@@ -94,6 +98,8 @@ To add a local video file, simply add the full path of the video file as the fie
 ![image](https://github.com/user-attachments/assets/aae32f03-4393-4195-9a5e-6e4fdb6836fe)
 
 This method is currently untested - [please raise an issue on GitHub if it doesn't work](https://github.com/Valkyr-JS/hovercards/issues).
+
+As with using Stash scenes, you can set a comma-separated list of paths here and one will be chosen at random to be displayed on hover. However, any path that has a comma in it will break.
 
 ### Local video files - Docker
 
@@ -105,6 +111,10 @@ Take the path to the file from the `previews` folder, and add `/plugin/hovercard
 
 ![image](https://github.com/user-attachments/assets/dbb51e7c-25a2-4e87-87c1-14e476dcaa80)
 
+As with using Stash scenes, you can set a comma-separated list of paths here and one will be chosen at random to be displayed on hover. However, any path that has a comma in it will break.
+
 ### Externally hosted videos
 
 Technically, these should be supported. The plugin will attempt to find any path entered into the field value. However I regularly ran into CORS issues. If you have any suggestions, feel free to contact me on the [Stash Discord plugins channel](https://discord.com/channels/559159668438728723/742220889017417738) or [raise an issue on GitHub](https://github.com/Valkyr-JS/hovercards/issues).
+
+As with using Stash scenes, you can set a comma-separated list of URLs here and one will be chosen at random to be displayed on hover. However, any URLs that has a comma in it will break.

--- a/src/components/HoverGallery.tsx
+++ b/src/components/HoverGallery.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import getSourceValueFromList from "@/helpers/getSourceValueFromList";
+
+const { GQL } = window.PluginApi;
+
+interface IHoverGalleryProps {
+  hovercard_gallery: number;
+  preferOriginalImage: boolean;
+}
+
+const HoverGallery: React.FC<IHoverGalleryProps> = (props) => {
+  // Check if the user has set to use the original image instead of the preview.
+  const imgType = props.preferOriginalImage ? "/image" : "/thumbnail";
+
+  // Choose a random gallery from the list.
+  const value = getSourceValueFromList(props.hovercard_gallery);
+
+  // External galleries are not supported. If the value is anything other than a
+  // number, return `null`.
+  if (typeof value === "string") return null;
+
+  // Get a random image from the gallery
+  const query = GQL.useFindImagesQuery({
+    variables: {
+      filter: { per_page: 1, sort: "random" },
+      image_filter: {
+        galleries: {
+          value: [value.toString()],
+          modifier: CriterionModifier.Includes,
+        },
+      },
+    },
+  });
+
+  // Don't return the component if a valid image hasn't been found.
+  if (!query.data || query.data.findImages.images.length === 0) return null;
+
+  const imageID = query.data.findImages.images[0].id;
+  const src = "/image/" + imageID + imgType;
+
+  return (
+    <img
+      loading="lazy"
+      className="performer-card-image hover-image"
+      src={src}
+    />
+  );
+};
+
+export default HoverGallery;

--- a/src/components/HoverImage.tsx
+++ b/src/components/HoverImage.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import getSourceValueFromList from "@/helpers/getSourceValueFromList";
+
+interface IHoverImageProps {
+  hovercard_image: string | number;
+  preferOriginalImage: boolean;
+}
+
+const HoverImage: React.FC<IHoverImageProps> = (props) => {
+  // Check if the user has set to use the original image instead of the preview.
+  const imgType = props.preferOriginalImage ? "/image" : "/thumbnail";
+
+  // Choose a random source from the list
+  const value = getSourceValueFromList(props.hovercard_image);
+
+  // If the value is a number, it is the Stash image ID. Else, it is the URL.
+  const src = typeof value === "number" ? "/image/" + value + imgType : value;
+
+  return (
+    <img
+      loading="lazy"
+      className="performer-card-image hover-image"
+      src={src}
+    />
+  );
+};
+
+export default HoverImage;

--- a/src/components/HoverVideo.tsx
+++ b/src/components/HoverVideo.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useRef } from "react";
+import getSourceValueFromList from "@/helpers/getSourceValueFromList";
+
+interface IHoverVideoProps {
+  hovercard_video: string | number;
+  preferFullVideos: boolean;
+  soundActive: boolean;
+}
+
+const HoverVideo: React.FC<IHoverVideoProps> = ({ soundActive, ...props }) => {
+  const videoEl = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (videoEl?.current?.volume)
+      videoEl.current.volume = soundActive ? 0.05 : 0;
+  }, [soundActive]);
+
+  // Check if the user has set to use the full video stream instead of the
+  // preview.
+  const vidType = props.preferFullVideos ? "/stream" : "/preview";
+
+  // Choose a random source from the list
+  const value = getSourceValueFromList(props.hovercard_video);
+
+  // If the hover value is a number, it is the Stash image ID. Else, it is the
+  // URL.
+  const src = typeof value === "number" ? "/scene/" + value + vidType : value;
+
+  const mouseOverHandler: React.MouseEventHandler<HTMLVideoElement> = (e) =>
+    (e.target as HTMLVideoElement).play();
+
+  const mouseOutHandler: React.MouseEventHandler<HTMLVideoElement> = (e) =>
+    (e.target as HTMLVideoElement).pause();
+
+  return (
+    <video
+      className="performer-card-image hover-video"
+      disableRemotePlayback
+      playsInline
+      muted={!soundActive}
+      loop
+      preload="none"
+      onMouseOver={mouseOverHandler}
+      onMouseOut={mouseOutHandler}
+      ref={videoEl}
+      src={src}
+    />
+  );
+};
+
+export default HoverVideo;

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -3,11 +3,10 @@ import {
   IPerformerCardPropsExtended,
   IPerformerCustomFields,
 } from "@/pluginTypes/hovercards";
+import HoverGallery from "../HoverGallery";
 import HoverImage from "../HoverImage";
 import HoverVideo from "../HoverVideo";
 import "./Image.scss";
-
-const { GQL } = window.PluginApi;
 
 const Image: React.FC<IPerformerCardPropsExtended> = ({
   performer,
@@ -16,29 +15,9 @@ const Image: React.FC<IPerformerCardPropsExtended> = ({
   const { hovercard_gallery, hovercard_image, hovercard_video } =
     performer.custom_fields as IPerformerCustomFields;
 
-  // Get an image from the gallery
-  let hoverGalleryImageID;
-  if (!!hovercard_gallery) {
-    const query = GQL.useFindImagesQuery({
-      variables: {
-        filter: { per_page: 1, sort: "random" },
-        image_filter: {
-          galleries: {
-            value: [hovercard_gallery.toString()],
-            modifier: CriterionModifier.Includes,
-          },
-        },
-      },
-    });
-
-    if (query.data?.findImages.images.length) {
-      hoverGalleryImageID = query.data.findImages.images[0].id;
-    }
-  }
-
-  const hoverGallery = hoverGalleryImageID ? (
-    <HoverImage
-      hovercard_image={hoverGalleryImageID}
+  const hoverGallery = hovercard_gallery ? (
+    <HoverGallery
+      hovercard_gallery={hovercard_gallery}
       preferOriginalImage={props.config?.preferOriginalImage ?? false}
     />
   ) : null;

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useRef } from "react";
+import React from "react";
 import {
   IPerformerCardPropsExtended,
   IPerformerCustomFields,
-} from "@pluginTypes/hovercards";
+} from "@/pluginTypes/hovercards";
+import HoverImage from "../HoverImage";
+import HoverVideo from "../HoverVideo";
 import "./Image.scss";
 
 const { GQL } = window.PluginApi;
@@ -70,90 +72,3 @@ const Image: React.FC<IPerformerCardPropsExtended> = ({
 };
 
 export default Image;
-
-interface IHoverImageProps {
-  hovercard_image: string | number;
-  preferOriginalImage: boolean;
-}
-
-const HoverImage: React.FC<IHoverImageProps> = (props) => {
-  // Check if the user has set to use the original image instead of the preview.
-  const imgType = props.preferOriginalImage ? "/image" : "/thumbnail";
-
-  // Choose a random source from the list
-  const value = getSourceValueFromList(props.hovercard_image);
-
-  // If the value is a number, it is the Stash image ID. Else, it is the URL.
-  const src = typeof value === "number" ? "/image/" + value + imgType : value;
-
-  return (
-    <img
-      loading="lazy"
-      className="performer-card-image hover-image"
-      src={src}
-    />
-  );
-};
-
-interface IHoverVideoProps {
-  hovercard_video: string | number;
-  preferFullVideos: boolean;
-  soundActive: boolean;
-}
-
-const HoverVideo: React.FC<IHoverVideoProps> = ({ soundActive, ...props }) => {
-  const videoEl = useRef<HTMLVideoElement>(null);
-
-  useEffect(() => {
-    if (videoEl?.current?.volume)
-      videoEl.current.volume = soundActive ? 0.05 : 0;
-  }, [soundActive]);
-
-  // Check if the user has set to use the full video stream instead of the
-  // preview.
-  const vidType = props.preferFullVideos ? "/stream" : "/preview";
-
-  // Choose a random source from the list
-  const value = getSourceValueFromList(props.hovercard_video);
-
-  // If the hover value is a number, it is the Stash image ID. Else, it is the
-  // URL.
-  const src = typeof value === "number" ? "/scene/" + value + vidType : value;
-
-  const mouseOverHandler: React.MouseEventHandler<HTMLVideoElement> = (e) =>
-    (e.target as HTMLVideoElement).play();
-
-  const mouseOutHandler: React.MouseEventHandler<HTMLVideoElement> = (e) =>
-    (e.target as HTMLVideoElement).pause();
-
-  return (
-    <video
-      className="performer-card-image hover-video"
-      disableRemotePlayback
-      playsInline
-      muted={!soundActive}
-      loop
-      preload="none"
-      onMouseOver={mouseOverHandler}
-      onMouseOut={mouseOutHandler}
-      ref={videoEl}
-      src={src}
-    />
-  );
-};
-
-/** Get a random string/number value from a potential comma-separated string list or
- * single number. */
-function getSourceValueFromList(sources: string | number): string | number {
-  // Convert the sources into a list
-  const values =
-    typeof sources === "string"
-      ? sources.split(",").map((v) => (isNaN(+v) ? v : +v))
-      : [sources];
-
-  // Choose a random source from the list
-  const value = values[Math.floor(Math.random() * values.length)];
-  const trimmed = typeof value === "string" ? value.trim() : value;
-
-  return trimmed;
-}

--- a/src/helpers/getSourceValueFromList.ts
+++ b/src/helpers/getSourceValueFromList.ts
@@ -1,0 +1,17 @@
+/** Get a random string/number value from a potential comma-separated string list or
+ * single number. */
+export default function getSourceValueFromList(
+  sources: string | number
+): string | number {
+  // Convert the sources into a list
+  const values =
+    typeof sources === "string"
+      ? sources.split(",").map((v) => (isNaN(+v) ? v : +v))
+      : [sources];
+
+  // Choose a random source from the list
+  const value = values[Math.floor(Math.random() * values.length)];
+  const trimmed = typeof value === "string" ? value.trim() : value;
+
+  return trimmed;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { default as cx } from "classnames";
-import PerformerCardImage from "@components/Image";
-import { IPerformerCardPropsExtended } from "@pluginTypes/hovercards";
+import PerformerCardImage from "@/components/Image";
+import { IPerformerCardPropsExtended } from "@/pluginTypes/hovercards";
 import "./styles.scss";
 
 const { PluginApi } = window;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,9 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       /* Specify a set of entries that re-map imports to additional lookup locations. */
-      "@components/*": ["./src/components/*"],
-      "@pluginTypes/*": ["./types/*"]
+      "@/components/*": ["./src/components/*"],
+      "@/helpers/*": ["./src/helpers/*"],
+      "@/pluginTypes/*": ["./types/*"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/types/hovercards.d.ts
+++ b/types/hovercards.d.ts
@@ -12,6 +12,9 @@ interface IhovercardsConfig {
 }
 
 interface IPerformerCustomFields {
+  /** The ID of a Stash gallery. A random image in the gallery will be picked to
+   * be displayed on hover. */
+  hovercard_gallery?: number;
   /** Either the Stash ID number or the URL string for the hover image, or a
    * comma-separated string of either. */
   hovercard_image?: string | number;

--- a/types/hovercards.d.ts
+++ b/types/hovercards.d.ts
@@ -12,16 +12,16 @@ interface IhovercardsConfig {
 }
 
 interface IPerformerCustomFields {
-  /** Either the Stash ID number or the URL string for the hover image. */
+  /** Either the Stash ID number or the URL string for the hover image, or a
+   * comma-separated string of either. */
   hovercard_image?: string | number;
-  /** Either the Stash ID number or the URL string for the hover video. */
+  /** Either the Stash ID number or the URL string for the hover video, or a
+   * comma-separated string of either. */
   hovercard_video?: string | number;
 }
 
 interface IPerformerCardPropsExtended extends IPerformerCardProps {
   config?: IhovercardsConfig;
-  performer: Performer & {
-    custom_fields: IPerformerCustomFields;
-  };
+  performer: Performer;
   stashSettings: ConfigResult;
 }


### PR DESCRIPTION
* feat: Added option for using Stash galleries via `hovercard_gallery` custom field.
* feat: Added option to all hovercard options to use comma-separated lists of sources, with one chosen at random on page load.